### PR TITLE
Try to use RString as a buffer

### DIFF
--- a/benchmark/encoder.rb
+++ b/benchmark/encoder.rb
@@ -17,8 +17,8 @@ end
 def implementations(ruby_obj)
   state = JSON::State.new(JSON.dump_default_options)
   {
-    json: ["json", proc { JSON.generate(ruby_obj) }],
-    oj: ["oj", proc { Oj.dump(ruby_obj) }],
+    json: ["json-#{JSON::VERSION}", proc { JSON.generate(ruby_obj) }],
+    # oj: ["oj", proc { Oj.dump(ruby_obj) }],
   }
 end
 
@@ -49,6 +49,7 @@ def benchmark_encoding(benchmark_name, ruby_obj, check_expected: true, except: [
       end
       x.report(name, &block)
     end
+    x.save! "/tmp/json-bench-#{benchmark_name}"
     x.compare!(order: :baseline)
   end
   puts

--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -35,28 +35,17 @@ typedef unsigned char _Bool;
 # define MAYBE_UNUSED(x) x
 #endif
 
-enum fbuffer_type {
-    FBUFFER_HEAP_ALLOCATED = 0,
-    FBUFFER_STACK_ALLOCATED = 1,
-};
-
 typedef struct FBufferStruct {
-    enum fbuffer_type type;
     unsigned long initial_length;
-    unsigned long len;
-    unsigned long capa;
-    char *ptr;
+    VALUE buf;
     VALUE io;
 } FBuffer;
 
-#define FBUFFER_STACK_SIZE 512
 #define FBUFFER_IO_BUFFER_SIZE (16384 - 1)
 #define FBUFFER_INITIAL_LENGTH_DEFAULT 1024
 
-#define FBUFFER_PTR(fb) ((fb)->ptr)
-#define FBUFFER_LEN(fb) ((fb)->len)
+#define FBUFFER_PTR(fb) (RSTRING_PTR((fb)->buf))
 #define FBUFFER_CAPA(fb) ((fb)->capa)
-#define FBUFFER_PAIR(fb) FBUFFER_PTR(fb), FBUFFER_LEN(fb)
 
 static void fbuffer_free(FBuffer *fb);
 #ifndef JSON_GENERATOR
@@ -71,108 +60,65 @@ static inline void fbuffer_append_char(FBuffer *fb, char newchr);
 static VALUE fbuffer_finalize(FBuffer *fb);
 #endif
 
-static void fbuffer_stack_init(FBuffer *fb, unsigned long initial_length, char *stack_buffer, long stack_buffer_size)
+static void fbuffer_init(FBuffer *fb, unsigned long initial_length)
 {
     fb->initial_length = (initial_length > 0) ? initial_length : FBUFFER_INITIAL_LENGTH_DEFAULT;
-    if (stack_buffer) {
-        fb->type = FBUFFER_STACK_ALLOCATED;
-        fb->ptr = stack_buffer;
-        fb->capa = stack_buffer_size;
-    }
+    fb->buf = 0;
 }
 
 static void fbuffer_free(FBuffer *fb)
 {
-    if (fb->ptr && fb->type == FBUFFER_HEAP_ALLOCATED) {
-        ruby_xfree(fb->ptr);
-    }
+    // noop
 }
 
 static void fbuffer_clear(FBuffer *fb)
 {
-    fb->len = 0;
+    if (fb->buf) {
+        rb_str_set_len(fb->buf, 0);
+    }
 }
 
+#ifdef JSON_GENERATOR
 static void fbuffer_flush(FBuffer *fb)
 {
-    rb_io_write(fb->io, rb_utf8_str_new(fb->ptr, fb->len));
+    if (fb->buf) {
+        VALUE buf = fb->buf;
+        fb->buf = 0;
+        rb_enc_associate_index(buf, rb_utf8_encindex());
+        rb_io_write(fb->io, buf);
+    }
     fbuffer_clear(fb);
 }
+#endif
 
-static void fbuffer_realloc(FBuffer *fb, unsigned long required)
+static inline void fbuffer_prepare(FBuffer *fb)
 {
-    if (required > fb->capa) {
-        if (fb->type == FBUFFER_STACK_ALLOCATED) {
-            const char *old_buffer = fb->ptr;
-            fb->ptr = ALLOC_N(char, required);
-            fb->type = FBUFFER_HEAP_ALLOCATED;
-            MEMCPY(fb->ptr, old_buffer, char, fb->len);
-        } else {
-            REALLOC_N(fb->ptr, char, required);
-        }
-        fb->capa = required;
+    if (RB_UNLIKELY(!fb->buf)) {
+        fb->buf = rb_str_buf_new(fb->initial_length);
     }
 }
 
-static void fbuffer_do_inc_capa(FBuffer *fb, unsigned long requested)
-{
-    if (RB_UNLIKELY(fb->io)) {
-        if (fb->capa < FBUFFER_IO_BUFFER_SIZE) {
-            fbuffer_realloc(fb, FBUFFER_IO_BUFFER_SIZE);
-        } else {
-            fbuffer_flush(fb);
-        }
-
-        if (RB_LIKELY(requested < fb->capa)) {
-            return;
-        }
-    }
-
-    unsigned long required;
-
-    if (RB_UNLIKELY(!fb->ptr)) {
-        fb->ptr = ALLOC_N(char, fb->initial_length);
-        fb->capa = fb->initial_length;
-    }
-
-    for (required = fb->capa; requested > required - fb->len; required <<= 1);
-
-    fbuffer_realloc(fb, required);
-}
-
-static inline void fbuffer_inc_capa(FBuffer *fb, unsigned long requested)
-{
-    if (RB_UNLIKELY(requested > fb->capa - fb->len)) {
-        fbuffer_do_inc_capa(fb, requested);
-    }
-}
 
 static void fbuffer_append(FBuffer *fb, const char *newstr, unsigned long len)
 {
     if (len > 0) {
-        fbuffer_inc_capa(fb, len);
-        MEMCPY(fb->ptr + fb->len, newstr, char, len);
-        fb->len += len;
+        fbuffer_prepare(fb);
+        rb_str_cat(fb->buf, newstr, len);
     }
 }
 
 #ifdef JSON_GENERATOR
 static void fbuffer_append_str(FBuffer *fb, VALUE str)
 {
-    const char *newstr = StringValuePtr(str);
-    unsigned long len = RSTRING_LEN(str);
-
-    RB_GC_GUARD(str);
-
-    fbuffer_append(fb, newstr, len);
+    fbuffer_prepare(fb);
+    rb_str_append(fb->buf, str);
 }
 #endif
 
 static inline void fbuffer_append_char(FBuffer *fb, char newchr)
 {
-    fbuffer_inc_capa(fb, 1);
-    *(fb->ptr + fb->len) = newchr;
-    fb->len++;
+    fbuffer_prepare(fb);
+    rb_str_cat(fb->buf, &newchr, 1);
 }
 
 #ifdef JSON_GENERATOR
@@ -205,7 +151,13 @@ static VALUE fbuffer_finalize(FBuffer *fb)
         rb_io_flush(fb->io);
         return fb->io;
     } else {
-        VALUE result = rb_utf8_str_new(FBUFFER_PTR(fb), FBUFFER_LEN(fb));
+        VALUE result = fb->buf;
+        fb->buf = 0;
+        if (RB_UNLIKELY(!result)) {
+            result = rb_utf8_str_new("", 0);
+        } else {
+            rb_enc_associate_index(result, rb_utf8_encindex());
+        }
         fbuffer_free(fb);
         return result;
     }

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1079,11 +1079,10 @@ static VALUE cState_partial_generate(VALUE self, VALUE obj, generator_func func,
 {
     GET_STATE(self);
 
-    char stack_buffer[FBUFFER_STACK_SIZE];
     FBuffer buffer = {
         .io = RTEST(io) ? io : Qfalse,
     };
-    fbuffer_stack_init(&buffer, state->buffer_initial_length, stack_buffer, FBUFFER_STACK_SIZE);
+    fbuffer_init(&buffer, state->buffer_initial_length);
 
     struct generate_json_data data = {
         .buffer = &buffer,
@@ -1533,11 +1532,10 @@ static VALUE cState_m_generate(VALUE klass, VALUE obj, VALUE opts, VALUE io)
     state_init(&state);
     configure_state(&state, opts);
 
-    char stack_buffer[FBUFFER_STACK_SIZE];
     FBuffer buffer = {
         .io = RTEST(io) ? io : Qfalse,
     };
-    fbuffer_stack_init(&buffer, state.buffer_initial_length, stack_buffer, FBUFFER_STACK_SIZE);
+    fbuffer_init(&buffer, state.buffer_initial_length);
 
     struct generate_json_data data = {
         .buffer = &buffer,

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1506,14 +1506,13 @@ static char *JSON_decode_integer(JSON_Parser *json, char *p, VALUE *result)
         } else {
             fbuffer_clear(&json->fbuffer);
             fbuffer_append(&json->fbuffer, json->memo, len);
-            fbuffer_append_char(&json->fbuffer, '\0');
             *result = rb_cstr2inum(FBUFFER_PTR(&json->fbuffer), 10);
         }
         return p + 1;
 }
 
 
-#line 1517 "parser.c"
+#line 1516 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 6};
 enum {JSON_float_error = 0};
@@ -1521,7 +1520,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 735 "parser.rl"
+#line 734 "parser.rl"
 
 
 static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -1530,15 +1529,15 @@ static char *JSON_parse_number(JSON_Parser *json, char *p, char *pe, VALUE *resu
     bool is_float = false;
 
 
-#line 1534 "parser.c"
+#line 1533 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 743 "parser.rl"
+#line 742 "parser.rl"
     json->memo = p;
 
-#line 1542 "parser.c"
+#line 1541 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1578,24 +1577,24 @@ case 6:
 		goto st0;
 	goto tr7;
 tr7:
-#line 727 "parser.rl"
+#line 726 "parser.rl"
 	{ p--; {p++; cs = 7; goto _out;} }
 	goto st7;
 st7:
 	if ( ++p == pe )
 		goto _test_eof7;
 case 7:
-#line 1589 "parser.c"
+#line 1588 "parser.c"
 	goto st0;
 tr8:
-#line 728 "parser.rl"
+#line 727 "parser.rl"
 	{  is_float = true; }
 	goto st3;
 st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1599 "parser.c"
+#line 1598 "parser.c"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto st8;
 	goto st0;
@@ -1614,14 +1613,14 @@ case 8:
 		goto st0;
 	goto tr7;
 tr9:
-#line 728 "parser.rl"
+#line 727 "parser.rl"
 	{  is_float = true; }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 1625 "parser.c"
+#line 1624 "parser.c"
 	switch( (*p) ) {
 		case 43: goto st5;
 		case 45: goto st5;
@@ -1678,7 +1677,7 @@ case 10:
 	_out: {}
 	}
 
-#line 745 "parser.rl"
+#line 744 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         if (!is_float) {
@@ -1734,7 +1733,7 @@ case 10:
 
 
 
-#line 1738 "parser.c"
+#line 1737 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 22};
 enum {JSON_array_error = 0};
@@ -1742,7 +1741,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 825 "parser.rl"
+#line 824 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1755,14 +1754,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     long stack_head = json->stack->head;
 
 
-#line 1759 "parser.c"
+#line 1758 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 837 "parser.rl"
+#line 836 "parser.rl"
 
-#line 1766 "parser.c"
+#line 1765 "parser.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -1802,7 +1801,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 805 "parser.rl"
+#line 804 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1817,12 +1816,12 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1821 "parser.c"
+#line 1820 "parser.c"
 	_widec = (*p);
 	if ( 44 <= (*p) && (*p) <= 44 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -1869,14 +1868,14 @@ case 7:
 		goto st3;
 	goto st7;
 tr4:
-#line 817 "parser.rl"
+#line 816 "parser.rl"
 	{ p--; {p++; cs = 22; goto _out;} }
 	goto st22;
 st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1880 "parser.c"
+#line 1879 "parser.c"
 	goto st0;
 st8:
 	if ( ++p == pe )
@@ -1944,13 +1943,13 @@ case 13:
 			if ( 10 <= (*p) && (*p) <= 10 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 13 ) {
@@ -1958,19 +1957,19 @@ case 13:
 			if ( 47 <= (*p) && (*p) <= 47 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 32 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2009,13 +2008,13 @@ case 14:
 		if ( 47 <= (*p) && (*p) <= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) >= 42 ) {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2034,20 +2033,20 @@ case 15:
 		if ( (*p) <= 41 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 42 ) {
 		if ( 43 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2070,13 +2069,13 @@ case 16:
 			if ( 42 <= (*p) && (*p) <= 42 ) {
 				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 46 ) {
@@ -2084,19 +2083,19 @@ case 16:
 			if ( 48 <= (*p) )
  {				_widec = (short)(128 + ((*p) - -128));
 				if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 			}
 		} else if ( (*p) >= 47 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2120,20 +2119,20 @@ case 17:
 		if ( (*p) <= 9 ) {
 			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else if ( (*p) > 10 ) {
 		if ( 11 <= (*p) )
  {			_widec = (short)(128 + ((*p) - -128));
 			if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 		}
 	} else {
 		_widec = (short)(128 + ((*p) - -128));
 		if (
-#line 815 "parser.rl"
+#line 814 "parser.rl"
  json->allow_trailing_comma  ) _widec += 256;
 	}
 	switch( _widec ) {
@@ -2205,7 +2204,7 @@ case 21:
 	_out: {}
 	}
 
-#line 838 "parser.rl"
+#line 837 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         long count = json->stack->head - stack_head;
@@ -2399,7 +2398,7 @@ static VALUE json_string_unescape(JSON_Parser *json, char *string, char *stringE
 }
 
 
-#line 2403 "parser.c"
+#line 2402 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 9};
 enum {JSON_string_error = 0};
@@ -2407,7 +2406,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 1061 "parser.rl"
+#line 1060 "parser.rl"
 
 
 static int
@@ -2428,15 +2427,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     VALUE match_string;
 
 
-#line 2432 "parser.c"
+#line 2431 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 1081 "parser.rl"
+#line 1080 "parser.rl"
     json->memo = p;
 
-#line 2440 "parser.c"
+#line 2439 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2461,14 +2460,14 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 1043 "parser.rl"
+#line 1042 "parser.rl"
 	{
         *result = json_string_fastpath(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
         p--;
         {p++; cs = 9; goto _out;}
     }
-#line 1036 "parser.rl"
+#line 1035 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
@@ -2477,7 +2476,7 @@ tr2:
     }
 	goto st9;
 tr6:
-#line 1036 "parser.rl"
+#line 1035 "parser.rl"
 	{
         *result = json_string_unescape(json, json->memo + 1, p, json->parsing_name, json->parsing_name || json-> freeze, json->parsing_name && json->symbolize_names);
         {p = (( p + 1))-1;}
@@ -2489,7 +2488,7 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 2493 "parser.c"
+#line 2492 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -2577,7 +2576,7 @@ case 8:
 	_out: {}
 	}
 
-#line 1083 "parser.rl"
+#line 1082 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -2730,7 +2729,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 2734 "parser.c"
+#line 2733 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -2738,7 +2737,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 1249 "parser.rl"
+#line 1248 "parser.rl"
 
 
 /*
@@ -2755,8 +2754,7 @@ static VALUE cParser_parse(VALUE self)
     VALUE result = Qnil;
     GET_PARSER;
 
-    char stack_buffer[FBUFFER_STACK_SIZE];
-    fbuffer_stack_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT, stack_buffer, FBUFFER_STACK_SIZE);
+    fbuffer_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT);
 
     VALUE rvalue_stack_buffer[RVALUE_STACK_INITIAL_CAPA];
     rvalue_stack stack = {
@@ -2767,16 +2765,16 @@ static VALUE cParser_parse(VALUE self)
     json->stack = &stack;
 
 
-#line 2771 "parser.c"
+#line 2769 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1277 "parser.rl"
+#line 1275 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2780 "parser.c"
+#line 2778 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2810,7 +2808,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1241 "parser.rl"
+#line 1240 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2820,7 +2818,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2824 "parser.c"
+#line 2822 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2909,7 +2907,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1280 "parser.rl"
+#line 1278 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);
@@ -2933,8 +2931,7 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     JSON_Parser *json = &_parser;
     parser_init(json, source, opts);
 
-    char stack_buffer[FBUFFER_STACK_SIZE];
-    fbuffer_stack_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT, stack_buffer, FBUFFER_STACK_SIZE);
+    fbuffer_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT);
 
     VALUE rvalue_stack_buffer[RVALUE_STACK_INITIAL_CAPA];
     rvalue_stack stack = {
@@ -2945,16 +2942,16 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     json->stack = &stack;
 
 
-#line 2949 "parser.c"
+#line 2946 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 1315 "parser.rl"
+#line 1312 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 2958 "parser.c"
+#line 2955 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -2988,7 +2985,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 1241 "parser.rl"
+#line 1240 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -2998,7 +2995,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 3002 "parser.c"
+#line 2999 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -3087,7 +3084,7 @@ case 9:
 	_out: {}
 	}
 
-#line 1318 "parser.rl"
+#line 1315 "parser.rl"
 
     if (json->stack_handle) {
         rvalue_stack_eagerly_release(json->stack_handle);
@@ -3128,7 +3125,7 @@ static void JSON_free(void *ptr)
 static size_t JSON_memsize(const void *ptr)
 {
     const JSON_Parser *json = ptr;
-    return sizeof(*json) + FBUFFER_CAPA(&json->fbuffer);
+    return sizeof(*json);
 }
 
 static const rb_data_type_t JSON_Parser_type = {
@@ -3142,7 +3139,7 @@ static VALUE cJSON_parser_s_allocate(VALUE klass)
 {
     JSON_Parser *json;
     VALUE obj = TypedData_Make_Struct(klass, JSON_Parser, &JSON_Parser_type, json);
-    fbuffer_stack_init(&json->fbuffer, 0, NULL, 0);
+    fbuffer_init(&json->fbuffer, 0);
     return obj;
 }
 

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -712,7 +712,6 @@ static char *JSON_decode_integer(JSON_Parser *json, char *p, VALUE *result)
         } else {
             fbuffer_clear(&json->fbuffer);
             fbuffer_append(&json->fbuffer, json->memo, len);
-            fbuffer_append_char(&json->fbuffer, '\0');
             *result = rb_cstr2inum(FBUFFER_PTR(&json->fbuffer), 10);
         }
         return p + 1;
@@ -1262,8 +1261,7 @@ static VALUE cParser_parse(VALUE self)
     VALUE result = Qnil;
     GET_PARSER;
 
-    char stack_buffer[FBUFFER_STACK_SIZE];
-    fbuffer_stack_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT, stack_buffer, FBUFFER_STACK_SIZE);
+    fbuffer_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT);
 
     VALUE rvalue_stack_buffer[RVALUE_STACK_INITIAL_CAPA];
     rvalue_stack stack = {
@@ -1300,8 +1298,7 @@ static VALUE cParser_m_parse(VALUE klass, VALUE source, VALUE opts)
     JSON_Parser *json = &_parser;
     parser_init(json, source, opts);
 
-    char stack_buffer[FBUFFER_STACK_SIZE];
-    fbuffer_stack_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT, stack_buffer, FBUFFER_STACK_SIZE);
+    fbuffer_init(&json->fbuffer, FBUFFER_INITIAL_LENGTH_DEFAULT);
 
     VALUE rvalue_stack_buffer[RVALUE_STACK_INITIAL_CAPA];
     rvalue_stack stack = {
@@ -1355,7 +1352,7 @@ static void JSON_free(void *ptr)
 static size_t JSON_memsize(const void *ptr)
 {
     const JSON_Parser *json = ptr;
-    return sizeof(*json) + FBUFFER_CAPA(&json->fbuffer);
+    return sizeof(*json);
 }
 
 static const rb_data_type_t JSON_Parser_type = {
@@ -1369,7 +1366,7 @@ static VALUE cJSON_parser_s_allocate(VALUE klass)
 {
     JSON_Parser *json;
     VALUE obj = TypedData_Make_Struct(klass, JSON_Parser, &JSON_Parser_type, json);
-    fbuffer_stack_init(&json->fbuffer, 0, NULL, 0);
+    fbuffer_init(&json->fbuffer, 0);
     return obj;
 }
 

--- a/lib/json/version.rb
+++ b/lib/json/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JSON
-  VERSION = '2.9.0'
+  VERSION = '2.9.0-rstring'
 end


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20878

It's definitely simpler and less code if using only high level
`rb_str` APIs. However the performance is really bad.

```
== Encoding small mixed (34 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring   270.614k i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring      2.810M (± 0.7%) i/s  (355.92 ns/i) -     14.072M in   5.008785s

Comparison:
          json-2.9.0:  6841854.5 i/s
  json-2.9.0-rstring:  2809586.8 i/s - 2.44x  slower

== Encoding small nested array (121 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring   104.936k i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring      1.066M (± 0.9%) i/s  (938.47 ns/i) -      5.352M in   5.022882s

Comparison:
          json-2.9.0:  2769443.8 i/s
  json-2.9.0-rstring:  1065559.4 i/s - 2.60x  slower

== Encoding small hash (65 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring   288.458k i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring      2.965M (± 0.7%) i/s  (337.22 ns/i) -     15.000M in   5.058436s

Comparison:
          json-2.9.0:  7606155.3 i/s
  json-2.9.0-rstring:  2965448.7 i/s - 2.56x  slower

== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring    50.000 i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring    504.537 (± 0.8%) i/s    (1.98 ms/i) -      2.550k in   5.054431s

Comparison:
          json-2.9.0:      378.8 i/s
  json-2.9.0-rstring:      504.5 i/s - 1.33x  faster

== Encoding mostly utf8 (5001001 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring    38.000 i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring    378.373 (± 0.8%) i/s    (2.64 ms/i) -      1.900k in   5.021755s

Comparison:
          json-2.9.0:      303.5 i/s
  json-2.9.0-rstring:      378.4 i/s - 1.25x  faster

== Encoding integers (8009 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring     5.373k i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring     53.530k (± 1.6%) i/s   (18.68 μs/i) -    268.650k in   5.020019s

Comparison:
          json-2.9.0:    96002.0 i/s
  json-2.9.0-rstring:    53530.1 i/s - 1.79x  slower

== Encoding activitypub.json (52595 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring     1.060k i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring     10.621k (± 0.3%) i/s   (94.15 μs/i) -     54.060k in   5.089908s

Comparison:
          json-2.9.0:    22854.8 i/s
  json-2.9.0-rstring:    10621.1 i/s - 2.15x  slower

== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring    62.000 i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring    621.649 (± 0.5%) i/s    (1.61 ms/i) -      3.162k in   5.086598s

Comparison:
          json-2.9.0:     1354.1 i/s
  json-2.9.0-rstring:      621.6 i/s - 2.18x  slower

== Encoding twitter.json (466906 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring    97.000 i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring    983.052 (± 1.0%) i/s    (1.02 ms/i) -      4.947k in   5.032796s

Comparison:
          json-2.9.0:     2175.2 i/s
  json-2.9.0-rstring:      983.1 i/s - 2.21x  slower

== Encoding canada.json (2090234 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring     1.000 i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring     19.360 (± 0.0%) i/s   (51.65 ms/i) -     97.000 in   5.010646s

Comparison:
          json-2.9.0:       20.3 i/s
  json-2.9.0-rstring:       19.4 i/s - 1.05x  slower

== Encoding many #to_json calls (2701 bytes)
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  json-2.9.0-rstring     2.108k i/100ms
Calculating -------------------------------------
  json-2.9.0-rstring     21.399k (± 1.0%) i/s   (46.73 μs/i) -    107.508k in   5.024491s

Comparison:
          json-2.9.0:    31034.7 i/s
  json-2.9.0-rstring:    21399.2 i/s - 1.45x  slower
```