### PR TITLE
Repro for TruffleRuby rb_catch_obj bug 

### DIFF
--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -2,7 +2,6 @@
 require 'mkmf'
 
 $defs << "-DJSON_DEBUG" if ENV.fetch("JSON_DEBUG", "0") != "0"
-$defs << "-DJSON_WORKAROUND_RB_CATCH_BUG" if RUBY_ENGINE == 'truffleruby'
 
 have_func("rb_enc_interned_str", "ruby/encoding.h") # RUBY_VERSION >= 3.0
 have_func("rb_str_to_interned_str", "ruby.h") # RUBY_VERSION >= 3.0

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2411,6 +2411,7 @@ struct json_parse_any_args {
 
 static VALUE json_parse_any_resumable_safe0(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, _args))
 {
+    fprintf(stderr, "inside rb_catch_obj\n");
     struct json_parse_any_args *args = (struct json_parse_any_args *)_args;
     return (VALUE)json_parse_any(args->state, args->config, true);
 }
@@ -2418,7 +2419,10 @@ static VALUE json_parse_any_resumable_safe0(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_a
 static VALUE json_parse_any_resumable_safe(VALUE _args)
 {
     struct json_parse_any_args *args = (struct json_parse_any_args *)_args;
+    fprintf(stderr, "about to call rb_catch_obj\n");
     VALUE result = rb_catch_obj(args->parser, json_parse_any_resumable_safe0, _args);
+    fprintf(stderr, "rb_catch_obj return value: ");
+    rb_p(result);
     return result == args->parser ? Qfalse : result;
 }
 
@@ -2494,7 +2498,13 @@ static VALUE cResumableParser_parse(VALUE self)
     };
     int status;
     const char *initial_cursor = parser->state.cursor;
-    parser->complete = rb_protect(json_parse_any_resumable_safe, (VALUE)&args, &status);
+    fprintf(stderr, "about to call rb_protect\n");
+    VALUE result = rb_protect(json_parse_any_resumable_safe, (VALUE)&args, &status);
+    fprintf(stderr, "rb_protect returned: ");
+    rb_p(result);
+    fprintf(stderr, "rb_protect rb_errinfo(): ");
+    rb_p(rb_errinfo());
+    parser->complete = result;
 
     if (status) {
         parser->complete = true; // a parse error is considered complete

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -672,35 +672,8 @@ static VALUE parse_error_new(JSON_ParserState *state, VALUE message, long line, 
     return exc;
 }
 
-#ifdef JSON_WORKAROUND_RB_CATCH_BUG
-#define JSON_CATCH_FUNC_ARGLIST(yielded_arg, func_args) VALUE func_args
-
-NORETURN(static) void parser_throw_eos(VALUE parser)
-{
-    VALUE exc = rb_exc_new_str(eParserError, rb_utf8_str_new_cstr("EOS"));
-    rb_ivar_set(exc, rb_intern("@resumable_parser_eos"), parser);
-    rb_exc_raise(exc);
-}
-
-static VALUE parser_catch_eos(VALUE parser, VALUE (*func)(VALUE args), VALUE func_args)
-{
-    int status;
-    VALUE result = rb_protect(func, func_args, &status);
-    if (status) {
-        VALUE error_source = rb_ivar_get(rb_errinfo(), rb_intern("@resumable_parser_eos"));
-        if (error_source == parser) {
-            rb_set_errinfo(Qnil);
-            return parser;
-        }
-        rb_jump_tag(status);
-    }
-    return result;
-}
-#else
-#define JSON_CATCH_FUNC_ARGLIST RB_BLOCK_CALL_FUNC_ARGLIST
 #define parser_throw_eos(parser) rb_throw_obj(parser, parser)
 #define parser_catch_eos(parser, func, func_args) rb_catch_obj(parser, func, func_args)
-#endif
 
 NORETURN(static) void raise_parse_error(const char *format, JSON_ParserState *state, bool eos)
 {
@@ -708,7 +681,7 @@ NORETURN(static) void raise_parse_error(const char *format, JSON_ParserState *st
         if (eos) {
             // the error will be swallowed by ResumableParser#parse, so no
             // point building a message or backtrace.
-            parser_throw_eos(state->parser);
+            rb_throw_obj(state->parser, state->parser);
         } else {
             // line and columns can't be accurate in resumable
             rb_exc_raise(parse_error_new(state, build_parse_error_message(format, state), 0, 0, eos));
@@ -2436,7 +2409,7 @@ struct json_parse_any_args {
     VALUE parser;
 };
 
-static VALUE json_parse_any_resumable_safe0(JSON_CATCH_FUNC_ARGLIST(yielded_arg, _args))
+static VALUE json_parse_any_resumable_safe0(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, _args))
 {
     struct json_parse_any_args *args = (struct json_parse_any_args *)_args;
     return (VALUE)json_parse_any(args->state, args->config, true);
@@ -2445,7 +2418,7 @@ static VALUE json_parse_any_resumable_safe0(JSON_CATCH_FUNC_ARGLIST(yielded_arg,
 static VALUE json_parse_any_resumable_safe(VALUE _args)
 {
     struct json_parse_any_args *args = (struct json_parse_any_args *)_args;
-    VALUE result = parser_catch_eos(args->parser, json_parse_any_resumable_safe0, _args);
+    VALUE result = rb_catch_obj(args->parser, json_parse_any_resumable_safe0, _args);
     return result == args->parser ? Qfalse : result;
 }
 

--- a/truffle-repro.rb
+++ b/truffle-repro.rb
@@ -1,0 +1,12 @@
+require 'json'
+
+parser = JSON::ResumableParser.new
+parser << '[' # unterminated array
+
+puts RUBY_VERSION
+if parser.parse
+  puts "BUG: #parse returned true"
+  exit 1
+else
+  puts "OK"
+end

--- a/truffle-repro.rb
+++ b/truffle-repro.rb
@@ -3,7 +3,7 @@ require 'json'
 parser = JSON::ResumableParser.new
 parser << '[' # unterminated array
 
-puts RUBY_VERSION
+puts RUBY_DESCRIPTION
 if parser.parse
   puts "BUG: #parse returned true"
   exit 1


### PR DESCRIPTION
repro script:

```ruby
require 'json'

parser = JSON::ResumableParser.new
parser << '[' # unterminated array

puts RUBY_DESCRIPTION
if parser.parse
  puts "BUG: #parse returned true"
  exit 1
else
  puts "OK"
end
```

```bash
bundle install
bundle exec rake compile
bundle exec ruby truffle-repro.rb
```

Behavior on Ruby 4.0.5 (expected):

```
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [arm64-darwin25]
about to call rb_protect
about to call rb_catch_obj
inside rb_catch_obj
rb_catch_obj return value: false
rb_protect returned: false
rb_protect rb_errinfo(): nil
OK
```

Behavior on TruffleRuby 33:

```
truffleruby 33.0.1 (2026-01-20), like ruby 3.3.7, Oracle GraalVM Native [arm64-darwin23]
about to call rb_protect
about to call rb_catch_obj
rb_protect returned: nil
rb_protect rb_errinfo(): nil
BUG: #parse returned true
```

